### PR TITLE
Add ruby 2.3 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3
 
 install:
   - "gem install bundler"


### PR DESCRIPTION
Ruby 2.3 has been released! Let's support it.

https://www.ruby-lang.org/en/news/2015/12/25/ruby-2-3-0-released/
