### PR TITLE
Upgrade cocaine to terrapin

### DIFF
--- a/lib/rack/secure_upload/scanner/avast.rb
+++ b/lib/rack/secure_upload/scanner/avast.rb
@@ -35,7 +35,7 @@ module Rack
         end
 
         def command
-          Cocaine::CommandLine.new(options[:bin_path], "-p 1 :path", :expected_outcodes => [0, 1])
+          Terrapin::CommandLine.new(options[:bin_path], "-p 1 :path", :expected_outcodes => [0, 1])
         end
 
         def default_options

--- a/lib/rack/secure_upload/scanner/base.rb
+++ b/lib/rack/secure_upload/scanner/base.rb
@@ -1,4 +1,4 @@
-require 'cocaine'
+require 'terrapin'
 require 'rack/secure_upload/errors'
 
 module Rack

--- a/lib/rack/secure_upload/scanner/fsecure.rb
+++ b/lib/rack/secure_upload/scanner/fsecure.rb
@@ -35,7 +35,7 @@ module Rack
         end
 
         def command
-          Cocaine::CommandLine.new(options[:bin_path], "--auto --virus-action1=remove :path", :expected_outcodes => [0, 1])
+          Terrapin::CommandLine.new(options[:bin_path], "--auto --virus-action1=remove :path", :expected_outcodes => [0, 1])
         end
 
         def default_options

--- a/rack-secure-upload.gemspec
+++ b/rack-secure-upload.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'logger', '>= 1.2'
   gem.add_dependency "rack", ">= 1.3"
-  gem.add_dependency "cocaine"
+  gem.add_dependency "terrapin"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", ">= 3.0"


### PR DESCRIPTION
When bundle update is done, the following warning is displayed on the Rails console.

```
===========================================
 DEPRECATION: The cocaine gem is deprecated. Please upgrade to terrapin. See https://github.com/thoughtbot/terrapin/ for further instructions.
===========================================
```

So, I upgrade cocaine to terrapin.

Details can be checked on the following page.
- https://github.com/thoughtbot/terrapin
- https://robots.thoughtbot.com/renaming-cocaine
