### PR TITLE
Support Ruby 2.3, 2.4 and 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
 
 install:
   - "gem install bundler"

--- a/rack-secure-upload.gemspec
+++ b/rack-secure-upload.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |gem|
   gem.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ['lib']
 
+  gem.required_ruby_version = ['>= 1.9', '< 2.6']
+
   gem.add_dependency 'logger', '>= 1.2'
   gem.add_dependency "rack", ">= 1.3"
   gem.add_dependency "terrapin"


### PR DESCRIPTION
Ruby 2.5 has been ready, so let's support Ruby 2.3, 2.4 and 2.5.