### PR TITLE
fix README config/application.rb for rails5

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ run MyApp
 In `config/application.rb`
 
 ```ruby
+# rails 5.x
+module MyApp
+  class Application < Rails::Application
+    config.middleware.insert_after ActionDispatch::Flash, Rack::SecureUpload::Middleware, :avast
+  end
+end
+
+# other
 module MyApp
   class Application < Rails::Application
     config.middleware.insert_before ActionDispatch::ParamsParser, Rack::SecureUpload::Middleware, :avast


### PR DESCRIPTION
The following error is displayed during rails5 upgrade.

> `assert_index': No such middleware to insert before: ActionDispatch::ParamsParser (RuntimeError)

There is no `ActionDispatch::ParamsParser` at rails5 middleware list.

```
# rails5
bin/rails middleware
use Rack::Sendfile
use ActionDispatch::Static
use ActionDispatch::Executor
use ActiveSupport::Cache::Strategy::LocalCache::Middleware
use Rack::Runtime
use Rack::MethodOverride
use ActionDispatch::RequestId
use RequestStore::Middleware
use Sprockets::Rails::QuietAssets
use Rails::Rack::Logger
use ActionDispatch::ShowExceptions
use ActionDispatch::DebugExceptions
use ActionDispatch::RemoteIp
use ActionDispatch::Reloader
use ActionDispatch::Callbacks
use ActiveRecord::Migration::CheckPending
use ActionDispatch::Cookies
use ActionDispatch::Session::RedisStore
use ActionDispatch::Flash
use Rack::Head
use Rack::UserAgent
use Rack::ConditionalGet
use Rack::ETag
use ExceptionNotification::Rack
use Bullet::Rack
```

So, I upgraded README.md for rails5.